### PR TITLE
Add LiquidGlass generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # opencodex
+
+This repository contains a simple **LiquidGlass** style image generator implemented in Python. The generator creates images similar to Apple's liquid glass aesthetic by layering translucent shapes over a gradient background and applying blur filters.
+
+## Requirements
+
+- Python 3.8+
+- Pillow (`pip install pillow`)
+
+## Usage
+
+Generate a default image (512x512 pixels):
+
+```bash
+python3 liquidglass.py
+```
+
+You can customize the size, number of shapes, and output path:
+
+```bash
+python3 liquidglass.py --width 800 --height 600 --shapes 8 --output result.png
+```
+
+The generated image will be saved to the specified output path.

--- a/liquidglass.py
+++ b/liquidglass.py
@@ -1,0 +1,70 @@
+import random
+from PIL import Image, ImageDraw, ImageFilter
+
+
+def generate_liquid_glass(width=512, height=512, shapes=5, output="liquidglass.png"):
+    """Generate a LiquidGlass style image.
+
+    Parameters
+    ----------
+    width: int
+        Width of the output image.
+    height: int
+        Height of the output image.
+    shapes: int
+        Number of translucent shapes to draw.
+    output: str
+        Path to save the generated image.
+    """
+
+    # Create gradient background
+    img = Image.new("RGBA", (width, height))
+    draw = ImageDraw.Draw(img)
+    for y in range(height):
+        r = int(127 + 128 * y / height)
+        g = int(127 + 128 * (height - y) / height)
+        b = 255
+        draw.line([(0, y), (width, y)], fill=(r, g, b))
+
+    overlay = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    o_draw = ImageDraw.Draw(overlay)
+
+    for _ in range(shapes):
+        radius = random.randint(width // 8, width // 3)
+        x = random.randint(0, width)
+        y = random.randint(0, height)
+        color = (
+            random.randint(150, 255),
+            random.randint(150, 255),
+            random.randint(150, 255),
+            random.randint(100, 180),
+        )
+        bbox = [
+            (x - radius, y - radius),
+            (x + radius, y + radius),
+        ]
+        o_draw.ellipse(bbox, fill=color)
+
+    overlay = overlay.filter(ImageFilter.GaussianBlur(radius=25))
+    img = Image.alpha_composite(img, overlay)
+    img = img.filter(ImageFilter.GaussianBlur(radius=1))
+    img.save(output)
+    print(f"Saved {output}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate a LiquidGlass style image")
+    parser.add_argument("--width", type=int, default=512, help="image width")
+    parser.add_argument("--height", type=int, default=512, help="image height")
+    parser.add_argument("--shapes", type=int, default=5, help="number of shapes")
+    parser.add_argument("--output", type=str, default="liquidglass.png", help="output file")
+    args = parser.parse_args()
+
+    generate_liquid_glass(
+        width=args.width,
+        height=args.height,
+        shapes=args.shapes,
+        output=args.output,
+    )


### PR DESCRIPTION
## Summary
- add Python generator `liquidglass.py` for LiquidGlass-style images
- document requirements and usage in README

## Testing
- `python3 -m py_compile liquidglass.py`
- `python3 liquidglass.py --width 300 --height 200 --shapes 3 --output test.png && ls -l test.png`

------
https://chatgpt.com/codex/tasks/task_e_68482c2ec1f083328971e912608c27d4